### PR TITLE
Update to version checks in plexupdate.sh

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -15,7 +15,8 @@ newversion=$(echo $jq | jq -r .nas.Synology.version)
 echo New Ver: $newversion
 curversion=$(synopkg version "Plex Media Server")
 echo Cur Ver: $curversion
-if [ "$newversion" != "$curversion" ]
+dpkg --compare-versions "$newversion" "gt" "$curversion"
+if [ $? -eq "0" ]
 then
 echo New Vers Available
 /usr/syno/bin/synonotify PKGHasUpgrade '{"[%HOSTNAME%]": $(hostname), "[%OSNAME%]": "Synology", "[%PKG_HAS_UPDATE%]": "Plex", "[%COMPANY_NAME%]": "Synology"}'


### PR DESCRIPTION
I suggest using dpkg --compare-versions for better semantic versioning checks (don't run into issues where you're installing an older version over a newer one, etc).